### PR TITLE
dev(ereb-wi) fix default schedule

### DIFF
--- a/ereb-wi/js/blocks/task_list/task_list.coffee
+++ b/ereb-wi/js/blocks/task_list/task_list.coffee
@@ -1,5 +1,5 @@
 class TaskList
-  defaultSchedule: '* */1 * * *'
+  defaultSchedule: '* * * * *'
   defaultCmd: 'echo'
 
   constructor: (wrapper) ->


### PR DESCRIPTION
Смысл у них один и тот же, но без лишней `/1` читается легче и приятнее. Ну и переводилка на человечий язык не будет перечислять все 24 часа.
